### PR TITLE
don't run the CI job on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
   merge_group:
-  push:
-    branches: ['master']
   schedule:
     - cron: '10 2 * * *' # At 02:10 UTC every day (a bit after rustup-components-history).
     - cron: '20,35,50 14,15 * * *' # for testing


### PR DESCRIPTION
Things already get tested pre-merge by the merge queue, so also running it again on master is a waste of resources.