### PR TITLE
field retagging has been the default for a while now

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-DEFAULTFLAGS="-Zmiri-retag-fields -Zrandomize-layout -Zmiri-strict-provenance"
+DEFAULTFLAGS="-Zrandomize-layout -Zmiri-strict-provenance"
 
 # apply our patch
 rm -rf rust-src-patched


### PR DESCRIPTION
So no need to set this flag.