### PR TITLE
Use nextest

### DIFF
--- a/ci-setup.sh
+++ b/ci-setup.sh
@@ -17,3 +17,5 @@ echo "Installing Rust version: $RUST_TOOLCHAIN"
 rustup toolchain install "$RUST_TOOLCHAIN" --component miri
 rustup override set "$RUST_TOOLCHAIN"
 cargo miri setup
+curl -L https://get.nexte.st/latest/linux | tar zxf -
+mv cargo-nextest ~/.cargo/bin/

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -17,8 +17,7 @@ core)
     for TARGET in x86_64-unknown-linux-gnu mips-unknown-linux-gnu; do
         echo "::group::Testing core ($TARGET, no validation, no Stacked Borrows, symbolic alignment)"
         MIRIFLAGS="$DEFAULTFLAGS -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmiri-symbolic-alignment-check" \
-            ./run-test.sh core --target $TARGET --lib --tests \
-            -- --skip align \
+            ./run-test.sh core --target $TARGET --lib --tests -E "not test(align)" \
             2>&1 | ts -i '%.s  '
         echo "::endgroup::"
         echo "::group::Testing core ($TARGET)"
@@ -91,11 +90,11 @@ simd)
 
     echo "::group::Testing portable-simd"
     MIRIFLAGS="$DEFAULTFLAGS" \
-        cargo miri test --lib --tests -- --skip ptr \
+        cargo miri nextest run --lib --tests -E "not test(ptr)" \
         2>&1 | ts -i '%.s  '
     # This contains some pointer tests that do int/ptr casts, so we need permissive provenance.
     MIRIFLAGS="$DEFAULTFLAGS -Zmiri-permissive-provenance" \
-        cargo miri test --lib --tests -- ptr \
+        cargo miri nextest run --lib --tests -- ptr \
         2>&1 | ts -i '%.s  '
     echo "::endgroup::"
     echo "::group::Testing portable-simd docs"

--- a/run-test.sh
+++ b/run-test.sh
@@ -37,4 +37,5 @@ cp "$MIRI_LIB_SRC/../Cargo.lock" Cargo.lock
 
 # run test
 cd ./${CRATE}_miri_test
-cargo miri test "$@"
+cargo miri nextest run "$@"
+cargo miri test --doc "$@"


### PR DESCRIPTION
Let's just see if this works before I get too exicited...

We might need a little abstraction; nextest doesn't support doctests because they don't have a name that can be fed back to `cargo test`.