### PR TITLE
Remove some unnecessary things

### DIFF
--- a/alloc_miri_test/Cargo.toml
+++ b/alloc_miri_test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "alloc_miri_test"
+name = "alloc"
 version = "0.0.0"
 autotests = false
 autobenches = false
@@ -10,9 +10,9 @@ rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.3.0"
 
 [[test]]
-name = "alloc"
+name = "alloc-lib"
 path = "../library/alloc/src/lib.rs"
 
 [[test]]
-name = "alloctests"
+name = "alloc-tests"
 path = "../library/alloc/tests/lib.rs"

--- a/alloc_miri_test/Cargo.toml
+++ b/alloc_miri_test/Cargo.toml
@@ -7,23 +7,18 @@ edition = "2021"
 
 [lib]
 name = "alloc_miri_test"
-path = "../library/alloc/src/lib.rs"
-
-[features]
-# Empty this crate to avoid two copies of liballoc.
-# See https://github.com/rust-lang/miri-test-libstd/issues/4.
-default = ["miri-test-libstd"]
-miri-test-libstd = []
-
-[dependencies]
-# This lets the crate access the `core` and `alloc` crates.
-core = { path = "../fake/core" }
-alloc = { path = "../fake/alloc" }
+path = "../empty.rs"
+test = false
+bench = false
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.3.0"
 
 [[test]]
-name = "collectionstests"
+name = "alloc"
+path = "../library/alloc/src/lib.rs"
+
+[[test]]
+name = "alloctests"
 path = "../library/alloc/tests/lib.rs"

--- a/alloc_miri_test/Cargo.toml
+++ b/alloc_miri_test/Cargo.toml
@@ -5,12 +5,6 @@ autotests = false
 autobenches = false
 edition = "2021"
 
-[lib]
-name = "alloc_miri_test"
-path = "../empty.rs"
-test = false
-bench = false
-
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.3.0"

--- a/alloc_miri_test/src/lib.rs
+++ b/alloc_miri_test/src/lib.rs
@@ -1,0 +1,4 @@
+#![feature(no_core, rustc_private)]
+#![no_core]
+extern crate alloc as realalloc;
+pub use realalloc::*;

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -17,13 +17,13 @@ core)
     for TARGET in x86_64-unknown-linux-gnu mips-unknown-linux-gnu; do
         echo "::group::Testing core ($TARGET, no validation, no Stacked Borrows, symbolic alignment)"
         MIRIFLAGS="$DEFAULTFLAGS -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmiri-symbolic-alignment-check" \
-            ./run-test.sh core --target $TARGET --lib --tests \
+            ./run-test.sh core --target $TARGET --tests \
             -- --skip align \
             2>&1 | ts -i '%.s  '
         echo "::endgroup::"
         echo "::group::Testing core ($TARGET)"
         MIRIFLAGS="$DEFAULTFLAGS" \
-            ./run-test.sh core --target $TARGET --lib --tests \
+            ./run-test.sh core --target $TARGET --tests \
             2>&1 | ts -i '%.s  '
         echo "::endgroup::"
         echo "::group::Testing core docs ($TARGET, ignore leaks)" && echo
@@ -39,7 +39,7 @@ alloc)
     for TARGET in x86_64-unknown-linux-gnu mips-unknown-linux-gnu; do
         echo "::group::Testing alloc ($TARGET, symbolic alignment)"
         MIRIFLAGS="$DEFAULTFLAGS -Zmiri-symbolic-alignment-check" \
-            ./run-test.sh alloc --target $TARGET --lib --tests \
+            ./run-test.sh alloc --target $TARGET --tests \
             2>&1 | ts -i '%.s  '
         echo "::endgroup::"
         echo "::group::Testing alloc docs ($TARGET, ignore leaks)"

--- a/core_miri_test/Cargo.toml
+++ b/core_miri_test/Cargo.toml
@@ -6,12 +6,6 @@ autotests = false
 autobenches = false
 edition = "2021"
 
-[lib]
-name = "core_miri_test"
-path = "../empty.rs"
-test = false
-bench = false
-
 [[test]]
 name = "coretests"
 path = "../library/core/tests/lib.rs"

--- a/core_miri_test/Cargo.toml
+++ b/core_miri_test/Cargo.toml
@@ -8,23 +8,13 @@ edition = "2021"
 
 [lib]
 name = "core_miri_test"
-path = "../library/core/src/lib.rs"
+path = "../empty.rs"
 test = false
 bench = false
-
-[features]
-# Empty this crate to avoid two copies of libcore.
-# See https://github.com/rust-lang/miri-test-libstd/issues/4.
-default = ["miri-test-libstd"]
-miri-test-libstd = []
 
 [[test]]
 name = "coretests"
 path = "../library/core/tests/lib.rs"
-
-[dependencies]
-# This lets the crate access the `core` crate.
-core = { path = "../fake/core" }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false }

--- a/fake/alloc/Cargo.toml
+++ b/fake/alloc/Cargo.toml
@@ -1,7 +1,0 @@
-[package]
-name = "alloc"
-version = "1.99.0"
-license = 'MIT OR Apache-2.0'
-
-[lib]
-path = "lib.rs"

--- a/fake/alloc/lib.rs
+++ b/fake/alloc/lib.rs
@@ -1,9 +1,0 @@
-#![feature(no_core)]
-#![no_core]
-
-// See rustc-std-workspace-core for why this crate is needed.
-
-// Rename the crate to avoid conflicting with the alloc module in liballoc.
-extern crate alloc as foo;
-
-pub use foo::*;

--- a/fake/core/Cargo.toml
+++ b/fake/core/Cargo.toml
@@ -1,7 +1,0 @@
-[package]
-name = "core"
-version = "1.99.0"
-license = 'MIT OR Apache-2.0'
-
-[lib]
-path = "lib.rs"

--- a/fake/core/lib.rs
+++ b/fake/core/lib.rs
@@ -1,5 +1,0 @@
-#![feature(no_core)]
-#![no_core]
-
-extern crate core;
-pub use core::*;

--- a/std_miri_test/Cargo.toml
+++ b/std_miri_test/Cargo.toml
@@ -17,7 +17,7 @@ path = "../library/std/src/lib.rs"
 # just a bunch of fake crates that reeexport sysroot crates, so that std's imports work out
 # (this works because we only build std as a test; the regular crate build is
 # completely empty thanks to the `miri-test-libstd` feature below)
-alloc = { path = "../fake/alloc" }
+alloc = { path = "../alloc_miri_test" }
 cfg-if = { path = "../fake/cfg-if" }
 libc = { path = "../fake/libc" }
 hashbrown = { path = "../fake/hashbrown" }

--- a/std_miri_test/Cargo.toml
+++ b/std_miri_test/Cargo.toml
@@ -17,7 +17,6 @@ path = "../library/std/src/lib.rs"
 # just a bunch of fake crates that reeexport sysroot crates, so that std's imports work out
 # (this works because we only build std as a test; the regular crate build is
 # completely empty thanks to the `miri-test-libstd` feature below)
-core = { path = "../fake/core" }
 alloc = { path = "../fake/alloc" }
 cfg-if = { path = "../fake/cfg-if" }
 libc = { path = "../fake/libc" }


### PR DESCRIPTION
@RalfJung This simplifies a few things, which might help in your adventure of putting this all inside the rust-lang/rust tree. If this is not useful, feel free to just close.

- Removes the need for the `miri-test-libstd` feature for `core`.
- Removes the need for the `miri-test-libstd` feature for `alloc`.
- Removes fake/core, which seems unnecessary.

This does not remove the need for `miri-test-libstd` from `std`, because if we move that `lib.rs` to a `[[test]]`, we will need to find another way to enable `#![feature(rustc_private)]` in there. (Not sure why the `#![feature(rustc_private)]` in the fake deps aren't enough. "Fixing" that could also be a solution, I suppose.)